### PR TITLE
Fix get_user auth issue

### DIFF
--- a/streamwatcher.py
+++ b/streamwatcher.py
@@ -65,7 +65,7 @@ def main():
                     username_list.append(user)
             
             for username in username_list:
-                user = tweepy.API().get_user(username)
+                user = tweepy.API(auth).get_user(username)
                 userid_list.append(user.id)
             
             follow_list = userid_list


### PR DESCRIPTION
This example produces the following when launched in filter mode:

``` python
Traceback (most recent call last):
  File "streamwatcher.py", line 91, in <module>
    main()
  File "streamwatcher.py", line 75, in main
    user = tweepy.API().get_user(username)
  File "build/bdist.linux-x86_64/egg/tweepy/binder.py", line 239, in _call
  File "build/bdist.linux-x86_64/egg/tweepy/binder.py", line 189, in execute
tweepy.error.TweepError: Failed to send request: local variable 'auth' referenced before assignment
```

This seems to be because we're not passing auth when constructing the API.
